### PR TITLE
feat: custom bucket policy for block-http traffic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "aws_s3_bucket_policy" "block-http" {
   count  = var.enabled && var.only_https_traffic ? 1 : 0
   bucket = aws_s3_bucket.s3_default[0].id
 
-  policy = jsonencode({
+  policy = var.block_http_bucket_policy != null ? var.block_http_bucket_policy : jsonencode({
     Version = "2012-10-17"
     Id      = "Blockhttp"
     Statement = [

--- a/variables.tf
+++ b/variables.tf
@@ -329,6 +329,12 @@ variable "only_https_traffic" {
   description = "This veriables use for only https traffic."
 }
 
+variable "block_http_bucket_policy" {
+  type        = any
+  default     = null
+  description = "Custome bucket policy to block https traffic"
+}
+
 variable "mfa_delete" {
   type        = string
   default     = "Disabled"


### PR DESCRIPTION
## what
- New attribute `block_http_bucket_policy`
- Can be used to provide custom bucket policy to block-http traffic and to create valid policy for cloudtrail.