### PR TITLE
feat: s3 object-lifecycle-rule to support different syntaxes for filter block

### DIFF
--- a/_example/complete/example.tf
+++ b/_example/complete/example.tf
@@ -117,7 +117,8 @@ module "s3_bucket" {
     years = null
   }
 
-  versioning = true
+  versioning    = true
+  force_destroy = true
   vpc_endpoints = [
     {
       endpoint_count = 1
@@ -211,9 +212,7 @@ module "s3_bucket" {
   lifecycle_configuration_rules = [
     {
       id                                             = "log"
-      prefix                                         = null
       enabled                                        = true
-      tags                                           = { "temp" : "true" }
       enable_glacier_transition                      = false
       enable_deeparchive_transition                  = false
       enable_standard_ia_transition                  = false
@@ -228,12 +227,14 @@ module "s3_bucket" {
       deeparchive_transition_days                    = 0
       storage_class                                  = "GLACIER"
       expiration_days                                = 365
+      filter = {
+        prefix = "myfolder1/myfolder2/"
+        tags   = { "temp" : "true" }
+      }
     },
     {
       id                                             = "log1"
-      prefix                                         = null
       enabled                                        = true
-      tags                                           = {}
       enable_glacier_transition                      = false
       enable_deeparchive_transition                  = false
       enable_standard_ia_transition                  = false
@@ -248,6 +249,10 @@ module "s3_bucket" {
       glacier_transition_days                        = 0
       deeparchive_transition_days                    = 0
       expiration_days                                = 365
+      filter = {
+        prefix = null
+        tags   = {}
+      }
     }
   ]
 

--- a/_example/website-s3/example.tf
+++ b/_example/website-s3/example.tf
@@ -51,9 +51,7 @@ module "s3_bucket" {
   lifecycle_configuration_rules = [
     {
       id                                             = "log"
-      prefix                                         = null
       enabled                                        = true
-      tags                                           = { "temp" : "true" }
       enable_glacier_transition                      = false
       enable_deeparchive_transition                  = false
       enable_standard_ia_transition                  = false
@@ -67,12 +65,14 @@ module "s3_bucket" {
       glacier_transition_days                        = 0
       deeparchive_transition_days                    = 0
       expiration_days                                = 365
+      filter = {
+        prefix = null
+        tags   = { "temp" : "true" }
+      }
     },
     {
       id                                             = "log1"
-      prefix                                         = null
       enabled                                        = true
-      tags                                           = {}
       enable_glacier_transition                      = false
       enable_deeparchive_transition                  = false
       enable_standard_ia_transition                  = false
@@ -86,6 +86,10 @@ module "s3_bucket" {
       glacier_transition_days                        = 0
       deeparchive_transition_days                    = 0
       expiration_days                                = 365
+      filter = {
+        prefix = null
+        tags   = {}
+      }
     }
   ]
 

--- a/variables.tf
+++ b/variables.tf
@@ -83,9 +83,8 @@ variable "enable_lifecycle_configuration_rules" {
 variable "lifecycle_configuration_rules" {
   type = list(object({
     id      = string
-    prefix  = string
     enabled = bool
-    tags    = map(string)
+    filter  = any
 
     enable_glacier_transition            = bool
     enable_deeparchive_transition        = bool


### PR DESCRIPTION
## what
- `filter` block syntax to support both syntaxes in `aws_s3_bucket_lifecycle_configuration`
Syntax-1
```tf
resource "aws_s3_bucket_lifecycle_configuration" "example" {
  ....
    filter {
      prefix = "logs/"
    }
  ...
}
```

Syntax-2 (with `and` )
```tf
resource "aws_s3_bucket_lifecycle_configuration" "example" {
  ...
    filter {
      and {
        tags = {
          Key1 = "Value1"
          Key2 = "Value2"
        }
      }
    }
  ...
}
```

## why
- Previously, only `and {}` syntax was supported which is causing below `XML` error when applying terraform.
> ERROR
│ Error: updating S3 Bucket Lifecycle Configuration (test-s3-bucket): operation error S3: PutBucketLifecycleConfiguration, https response error StatusCode: 400, RequestID: 9AXXXXXXXXXXJQ, HostID: BU6BxxxxxxxxxxQWVQ/XMrSRnaNrF/RFNQumxxxxxxxxxxxuJ0DRYpUCxxxxxxxxxx=, api error MalformedXML: The XML you provided was not well-formed or did not validate against our published schema
│ 
│   with module.test_s3_bucket.aws_s3_bucket_lifecycle_configuration.default[0],
│   on .terraform/modules/test_s3_bucket/main.tf line 287, in resource "aws_s3_bucket_lifecycle_configuration" "default":
│  287: resource "aws_s3_bucket_lifecycle_configuration" "default" {

## References -
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration
https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master