### PR TITLE
Fixed deprecated arguments and added workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,28 @@
+name: 'PR Validation'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  pr-validation:
+    uses: clouddrove/github-shared-workflows/.github/workflows/pr_checks.yml@master
+    secrets: inherit
+    with:
+      types: |
+        fix
+        feat
+        docs
+        ci
+        chore
+        test
+        refactor
+        style
+        perf
+        build
+        revert
+      checkLabels: true 


### PR DESCRIPTION
## what
* Fixed S3 lifecycle filter logic to avoid creating invalid and blocks.
* Ensured and filters are only generated when lifecycle tags are present.
* Added pr-check workflow as well.

## why
* AWS S3 lifecycle rules do not allow empty tags in and filters.
* This prevents Terraform apply failures and improves module stability.

