### PR TITLE
fix: Correct date values in dynamic transition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -387,8 +387,18 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
         for_each = rule.value.enable_deeparchive_transition ? [1] : []
 
         content {
-          newer_noncurrent_versions = rule.value.noncurrent_version_glacier_transition_newer
+          newer_noncurrent_versions = rule.value.noncurrent_version_deeparchive_transition_newer
           noncurrent_days           = rule.value.noncurrent_version_deeparchive_transition_days
+          storage_class             = rule.value.storage_class
+        }
+      }
+
+      dynamic "noncurrent_version_transition" {
+        for_each = rule.value.enable_standard_ia_transition ? [1] : []
+
+        content {
+          newer_noncurrent_versions = rule.value.noncurrent_version_standard_ia_transition_newer
+          noncurrent_days           = rule.value.noncurrent_version_glacier_transition_days
           storage_class             = rule.value.storage_class
         }
       }
@@ -407,7 +417,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
         for_each = rule.value.enable_deeparchive_transition ? [1] : []
 
         content {
-          date          = rule.value.glacier_transition_date
+          date          = rule.value.deeparchive_transition_date
           days          = rule.value.deeparchive_transition_days
           storage_class = rule.value.storage_class
         }
@@ -417,7 +427,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
         for_each = rule.value.enable_standard_ia_transition ? [1] : []
 
         content {
-          date          = rule.value.glacier_transition_date
+          date          = rule.value.standard_ia_transition_date
           days          = rule.value.standard_transition_days
           storage_class = rule.value.storage_class
         }

--- a/variables.tf
+++ b/variables.tf
@@ -93,14 +93,24 @@ variable "lifecycle_configuration_rules" {
     enable_noncurrent_version_expiration = bool
 
     abort_incomplete_multipart_upload_days         = number
-    noncurrent_version_glacier_transition_days     = number
-    noncurrent_version_deeparchive_transition_days = number
-    noncurrent_version_expiration_days             = number
+    noncurrent_version_glacier_transition_days     = optional(number)
+    noncurrent_version_deeparchive_transition_days = optional(number)
+    noncurrent_version_expiration_days             = optional(number)
 
-    standard_transition_days    = number
-    glacier_transition_days     = number
-    deeparchive_transition_days = number
-    expiration_days             = number
+    noncurrent_version_glacier_transition_newer     = optional(number)
+    noncurrent_version_deeparchive_transition_newer = optional(number)
+    noncurrent_version_standard_ia_transition_newer = optional(number)
+
+    storage_class = optional(string)
+
+    glacier_transition_date     = optional(number)
+    standard_ia_transition_date = optional(number)
+    deeparchive_transition_date = optional(number)
+
+    standard_transition_days    = optional(number)
+    glacier_transition_days     = optional(number)
+    deeparchive_transition_days = optional(number)
+    expiration_days             = optional(number)
   }))
   default     = null
   description = "A list of lifecycle rules"


### PR DESCRIPTION
## what
- Fixed incorrect attribute references in **S3 lifecycle transition and noncurrent version transition blocks**.
- Corrected issues where:
    - `glacier_transition_date` was incorrectly used for **Standard-IA** and **Deep Archive** transitions.
    - Noncurrent transition day values were referencing the wrong lifecycle variables.
- Updated `variables.tf` to:
    - Convert lifecycle rule fields to **`optional()`** to avoid forced values.
    - Clearly separate **date-based** and **day-based** lifecycle transition inputs.